### PR TITLE
feat: add response validation with ResponseValidator, ValidationException, and onResponseValidated hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-03-25
+
+### Added
+
+- **`ResponseValidator` Interface**: A pluggable contract for validating HTTP responses before they are returned to the caller. Implement `validate(response: Response<T>): Promise<void> | void` to enforce schema constraints or business rules. Both sync and async validators are supported.
+- **`ValidationException<TCause>`**: A new generic exception class thrown when a validator rejects a response. The optional `TCause` parameter narrows the type of `cause` (e.g. `ValidationException<ZodError>`) for typed access without casting; defaults to `unknown`. Carries the original `Response` object for inspection, exposes `toJSON()` for structured logging, and is not retryable.
+- **`isValidationException` Type Guard**: Consistent with the existing guard pattern, enables safe narrowing without `instanceof`.
+- **`RequestBuilder.validateWith(...validators)`**: Registers one or more validators on a request via rest parameters. Validators accumulate across multiple calls and are stored on the `Request` model.
+- **`HttpValidatedResponseInterceptor`**: A new interceptor interface with an `onResponseValidated` hook that fires only after all registered validators pass. Complements the existing `onResponse` hook which always fires regardless of validation outcome.
+- **Interceptor Lifecycle for Validation**: The full request lifecycle is now `onRequest → HTTP call → onResponse → validators → onResponseValidated → caller`. If a validator throws, `onResponseValidated` is skipped and `onError` is triggered instead — while `onResponse` always runs.
+- **Automatic Error Wrapping in Validators**: Non-`BaseAdapterException` errors thrown by validators (e.g. `ZodError`, `TypeError`) are automatically wrapped in `ValidationException` with the original error as `cause`. `BaseAdapterException` subclasses are re-thrown as-is.
+
 ## [3.1.0] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A professional, robust, and highly configurable HTTP client adapter designed for
 
 - **Fluent Request Builder:** Construct complex HTTP requests with an intuitive, chainable API.
 - **Structured Exception Hierarchy:** Every HTTP status code and network failure maps to a dedicated, named exception class with rich metadata, `isRetryable()` signals, and structured `toJSON()` serialization.
+- **Response Validation:** Attach one or more `ResponseValidator` implementations to any request to enforce schema constraints or business rules automatically before the response reaches your code.
 - **Interceptor Architecture:** Easily implement middleware for logging, authentication, error handling, and data transformation.
 - **Resilience & Reliability:** Built-in support for retry policies (Exponential Backoff, etc.) and a generic **Circuit Breaker** to handle transient failures gracefully and prevent cascading failures in S2S communication.
 - **Type Safety:** Fully typed requests and responses using generics, ensuring type safety across your application.
@@ -230,6 +231,72 @@ Every exception automatically carries a `RequestContext` object (`method`, `url`
   }
 }
 ```
+
+### Response Validators
+
+Attach validators to a request to automatically enforce schema constraints or business rules on the response before it reaches your code. Validators run sequentially after the HTTP call succeeds and before response-side interceptors. The first validator that throws halts the chain.
+
+```typescript
+import { ResponseValidator, ValidationException, Response } from '@yildizpay/http-adapter';
+
+class PaymentStatusValidator implements ResponseValidator<IyzicoResponse> {
+  validate(response: Response<IyzicoResponse>): void {
+    if (response.data.status !== 'success') {
+      throw new ValidationException(
+        `Payment failed: ${response.data.errorMessage}`,
+        response,
+      );
+    }
+  }
+}
+
+// Works with any schema validation library — zero coupling to Zod, Joi, etc.
+class PaymentSchemaValidator implements ResponseValidator<unknown> {
+  validate(response: Response<unknown>): void {
+    IyzicoResponseSchema.parse(response.data); // Zod throws on mismatch
+  }
+}
+
+const request = new RequestBuilder('https://api.iyzipay.com')
+  .setEndpoint('/payment/auth')
+  .setMethod(HttpMethod.POST)
+  .setBody(dto)
+  .validateWith(new PaymentSchemaValidator(), new PaymentStatusValidator())
+  .build();
+```
+
+Catching a validation failure:
+
+```typescript
+import { isValidationException } from '@yildizpay/http-adapter';
+
+} catch (error) {
+  if (isValidationException(error)) {
+    console.error('Validation failed:', error.message);
+    console.error('Raw response:', error.response.data);
+  }
+}
+```
+
+Non-`BaseAdapterException` errors thrown inside a validator (e.g. `ZodError`) are automatically wrapped in `ValidationException` with the original error available as `cause`. Use the generic parameter for typed access:
+
+```typescript
+} catch (error) {
+  if (isValidationException<ZodError>(error) && error.cause) {
+    console.error('Schema issues:', error.cause.issues);
+  }
+}
+```
+
+The full interceptor lifecycle when validators are registered:
+
+```
+onRequest → HTTP call → onResponse → validators → onResponseValidated → caller
+                                          ↓ (on failure)
+                                       onError
+```
+
+`onResponse` always fires. `onResponseValidated` only fires when all validators pass — ideal for caching or downstream side effects that require a business-valid response.
 
 ### Error Interceptor
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -12,6 +12,7 @@ Node.js tabanlı kurumsal uygulamalar için tasarlanmış profesyonel ve yüksek
 
 - **Fluent Request Builder:** Sezgisel ve zincirlenebilir bir API ile karmaşık HTTP isteklerini kolayca oluşturun.
 - **Structured Exception Hierarchy:** Her HTTP durum kodu ve ağ hatası, zengin metadata, `isRetryable()` sinyali ve `toJSON()` desteğiyle ayrı bir exception sınıfına dönüştürülür.
+- **Response Validation:** Herhangi bir request'e bir veya daha fazla `ResponseValidator` ekleyerek schema kısıtlamalarını veya business rule'ları response kodunuza ulaşmadan otomatik olarak denetleyebilirsiniz.
 - **Interceptor Mimarisi:** Loglama, kimlik doğrulama, hata yönetimi ve veri dönüşümü gibi middleware işlemlerini zahmetsizce entegre edin.
 - **Resilience & Reliability:** S2S entegrasyonlarında geçici hataları zarif bir şekilde yönetmek için Exponential Backoff gibi retry policy'ler ve built-in **Circuit Breaker** içerir.
 - **Type Safety:** Generic'ler kullanılarak tam olarak tiplendirilmiş request ve response'lar ile uygulama genelinde tip güvenliği sağlanır.
@@ -230,6 +231,72 @@ Her exception, kaynak request'ten alınan `RequestContext` objesini (`method`, `
   }
 }
 ```
+
+### Response Validator'lar
+
+Request'e validator ekleyerek schema kısıtlamalarını veya business rule'ları response kodunuza ulaşmadan otomatik olarak denetleyebilirsiniz. Validator'lar HTTP çağrısı başarılı olduktan sonra, response-side interceptor'lardan önce sırayla çalışır. İlk hata veren validator chain'i durdurur.
+
+```typescript
+import { ResponseValidator, ValidationException, Response } from '@yildizpay/http-adapter';
+
+class PaymentStatusValidator implements ResponseValidator<IyzicoResponse> {
+  validate(response: Response<IyzicoResponse>): void {
+    if (response.data.status !== 'success') {
+      throw new ValidationException(
+        `Payment failed: ${response.data.errorMessage}`,
+        response,
+      );
+    }
+  }
+}
+
+// Zod, Joi gibi herhangi bir validation kütüphanesiyle çalışır
+class PaymentSchemaValidator implements ResponseValidator<unknown> {
+  validate(response: Response<unknown>): void {
+    IyzicoResponseSchema.parse(response.data); // Zod uyuşmazlıkta exception fırlatır
+  }
+}
+
+const request = new RequestBuilder('https://api.iyzipay.com')
+  .setEndpoint('/payment/auth')
+  .setMethod(HttpMethod.POST)
+  .setBody(dto)
+  .validateWith(new PaymentSchemaValidator(), new PaymentStatusValidator())
+  .build();
+```
+
+Validation hatasını yakalamak:
+
+```typescript
+import { isValidationException } from '@yildizpay/http-adapter';
+
+} catch (error) {
+  if (isValidationException(error)) {
+    console.error('Validation başarısız:', error.message);
+    console.error('Ham response:', error.response.data);
+  }
+}
+```
+
+Validator içinde fırlatılan `BaseAdapterException` olmayan hatalar (örn. `ZodError`) otomatik olarak `ValidationException`'a sarılır; orijinal hata `cause`'ta tutulur. Typed erişim için generic parametre kullanılabilir:
+
+```typescript
+} catch (error) {
+  if (isValidationException<ZodError>(error) && error.cause) {
+    console.error('Schema hataları:', error.cause.issues);
+  }
+}
+```
+
+Validator kayıtlıyken tam interceptor lifecycle'ı:
+
+```
+onRequest → HTTP call → onResponse → validators → onResponseValidated → caller
+                                          ↓ (hata durumunda)
+                                       onError
+```
+
+`onResponse` her zaman çalışır. `onResponseValidated` yalnızca tüm validator'lar geçtiğinde çalışır — business açısından geçerli bir response gerektiren cache veya side effect işlemleri için idealdir.
 
 ### Error Interceptor
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yildizpay/http-adapter",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Enterprise-grade, zero-dependency HTTP adapter for Node.js with pluggable client abstractions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/builders/request.builder.ts
+++ b/src/builders/request.builder.ts
@@ -2,6 +2,7 @@ import { HttpMethod } from '../common/enums/http-method.enum';
 import { HttpBody } from '../common/types/http.types';
 import { Request } from '../models/request';
 import { RequestOptions } from '../models/request-options';
+import { ResponseValidator } from '../contracts/response-validator.contract';
 
 /**
  * A fluent builder for constructing HTTP requests.
@@ -21,6 +22,7 @@ export class RequestBuilder {
   private body: HttpBody = {};
   private queryParams: Record<string, string> = {};
   private options: RequestOptions;
+  private readonly validators: ResponseValidator[] = [];
 
   /**
    * Initializes a new instance of the RequestBuilder class.
@@ -278,6 +280,25 @@ export class RequestBuilder {
   }
 
   /**
+   * Registers one or more response validators for this request.
+   *
+   * Validators are executed sequentially by the `HttpAdapter` after a successful
+   * response is received. The first validator that throws halts the chain.
+   *
+   * @param validators - One or more `ResponseValidator` instances to register.
+   * @returns The current instance of RequestBuilder for method chaining.
+   *
+   * @example
+   * ```typescript
+   * builder.validateWith(new SchemaValidator(), new BusinessRuleValidator())
+   * ```
+   */
+  public validateWith(...validators: ResponseValidator[]): this {
+    this.validators.push(...validators);
+    return this;
+  }
+
+  /**
    * Builds and returns a new Request object based on the current configuration.
    *
    * @returns A constructed Request object ready to be executed.
@@ -291,6 +312,7 @@ export class RequestBuilder {
       this.queryParams,
       this.body ? { ...this.body } : undefined,
       this.options,
+      this.validators,
     );
   }
 }

--- a/src/contracts/http-interceptor.contract.ts
+++ b/src/contracts/http-interceptor.contract.ts
@@ -33,12 +33,26 @@ export interface HttpResponseInterceptor {
   onResponse(response: Response): Promise<Response>;
 }
 
+export interface HttpValidatedResponseInterceptor {
+  /**
+   * Intercepts an HTTP response after all registered validators have passed.
+   *
+   * Use this method for operations that require a business-valid response, such as
+   * caching, data transformation, or triggering downstream side effects.
+   * This hook is NOT called if any validator throws a `ValidationException`.
+   *
+   * @param response - The validated response object.
+   * @returns A promise that resolves to the modified (or original) response object.
+   */
+  onResponseValidated(response: Response): Promise<Response>;
+}
+
 export interface HttpErrorInterceptor {
   /**
    * Intercepts errors that occur during the HTTP request lifecycle.
    *
-   * Use this method to handle network errors, timeouts, or non-success HTTP status codes
-   * centrally. You can also re-throw a custom error or return a fallback value.
+   * Triggered by network failures, HTTP error status codes, and `ValidationException`s.
+   * Use this method to handle errors centrally, re-throw a custom error, or return a fallback.
    *
    * @param error - The error that occurred.
    * @param request - The request during which the error occurred.
@@ -49,4 +63,5 @@ export interface HttpErrorInterceptor {
 
 export type HttpInterceptor = Partial<HttpRequestInterceptor> &
   Partial<HttpResponseInterceptor> &
+  Partial<HttpValidatedResponseInterceptor> &
   Partial<HttpErrorInterceptor>;

--- a/src/contracts/response-validator.contract.ts
+++ b/src/contracts/response-validator.contract.ts
@@ -1,0 +1,29 @@
+import { Response } from '../models/response';
+
+/**
+ * Contract for validating HTTP responses before they are returned to the caller.
+ *
+ * Implement this interface to enforce business rules or schema constraints on a
+ * response. Validators are registered on a request via `RequestBuilder.validateWith()`
+ * and are executed sequentially by the `HttpAdapter` after a successful HTTP response
+ * is received. The first validator that throws will halt the chain.
+ *
+ * @template T - The expected shape of the response data.
+ *
+ * @example
+ * ```typescript
+ * class PaymentStatusValidator implements ResponseValidator<IyzicoResponse> {
+ *   async validate(response: Response<IyzicoResponse>): Promise<void> {
+ *     if (response.data.status !== 'success') {
+ *       throw new ValidationException(
+ *         `Payment failed: ${response.data.errorMessage}`,
+ *         response,
+ *       );
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export interface ResponseValidator<T = unknown> {
+  validate(response: Response<T>): Promise<void> | void;
+}

--- a/src/core/http.adapter.ts
+++ b/src/core/http.adapter.ts
@@ -8,6 +8,8 @@ import { RetryExecutor } from '../resilience/retry-executor';
 import { CircuitBreaker } from '../resilience/circuit-breaker/circuit-breaker';
 import { HttpClientContract } from '../contracts/http-client.contract';
 import { ErrorConverter } from './error.converter';
+import { BaseAdapterException } from '../exceptions/base-adapter.exception';
+import { ValidationException } from '../exceptions/validation.exception';
 
 /**
  * The core HTTP adapter that orchestrates outbound requests.
@@ -134,10 +136,29 @@ export class HttpAdapter {
         requestContext,
       );
 
-      /* Apply response-side interceptors in registration order */
+      /* Apply response-side interceptors — runs regardless of validation outcome */
       for (const interceptor of this.interceptors) {
         if (interceptor.onResponse) {
           response = (await interceptor.onResponse(response)) as Response<T>;
+        }
+      }
+
+      /* Run response validators sequentially — first failure halts the chain.
+         Non-BaseAdapterException errors (e.g. ZodError) are wrapped in ValidationException
+         so callers always receive a typed, inspectable exception. */
+      for (const validator of request.validators) {
+        try {
+          await validator.validate(response);
+        } catch (err) {
+          if (err instanceof BaseAdapterException) throw err;
+          throw new ValidationException('Response validation failed', response, err);
+        }
+      }
+
+      /* Apply post-validation interceptors — only reached when all validators pass */
+      for (const interceptor of this.interceptors) {
+        if (interceptor.onResponseValidated) {
+          response = (await interceptor.onResponseValidated(response)) as Response<T>;
         }
       }
 

--- a/src/exceptions/exception.guards.ts
+++ b/src/exceptions/exception.guards.ts
@@ -10,6 +10,7 @@ import {
   HostUnreachableException,
 } from './network.exceptions';
 import { UnknownException } from './unknown.exception';
+import { ValidationException } from './validation.exception';
 
 export function isBaseAdapterException(error: unknown): error is BaseAdapterException {
   return error instanceof BaseAdapterException;
@@ -51,4 +52,10 @@ export function isCircuitBreakerOpenException(
   error: unknown,
 ): error is CircuitBreakerOpenException {
   return error instanceof CircuitBreakerOpenException;
+}
+
+export function isValidationException<TCause = unknown>(
+  error: unknown,
+): error is ValidationException<TCause> {
+  return error instanceof ValidationException;
 }

--- a/src/exceptions/validation.exception.ts
+++ b/src/exceptions/validation.exception.ts
@@ -1,0 +1,39 @@
+import { Response } from '../models/response';
+import { BaseAdapterException } from './base-adapter.exception';
+
+/**
+ * Thrown when a `ResponseValidator` determines that a response does not satisfy
+ * the expected schema or business rules.
+ *
+ * Carries the original `Response` object so callers can inspect the raw data
+ * that caused the failure.
+ *
+ * The optional generic parameter `TCause` narrows the type of `cause` for callers
+ * who know the underlying error (e.g. `ValidationException<ZodError>`). When omitted,
+ * `cause` is typed as `unknown` and can be cast manually.
+ *
+ * @template TCause - The expected type of the underlying cause (default: `unknown`).
+ */
+export class ValidationException<TCause = unknown> extends BaseAdapterException {
+  public override readonly name = 'ValidationException';
+  public readonly response: Response;
+  public override readonly cause: TCause | undefined;
+
+  public constructor(message: string, response: Response, cause?: TCause) {
+    super(message, 'ERR_VALIDATION', cause);
+    this.response = response;
+    this.cause = cause;
+    Object.setPrototypeOf(this, ValidationException.prototype);
+  }
+
+  public override toJSON(): Record<string, unknown> {
+    return {
+      ...super.toJSON(),
+      response: {
+        status: this.response.status,
+        data: this.response.data,
+        request: this.response.requestContext,
+      },
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export * from './models/request-context';
 // Contracts
 export * from './contracts/http-interceptor.contract';
 export * from './contracts/retry-policy.contract';
+export * from './contracts/response-validator.contract';
 
 // Resilience
 export * from './resilience/retry.policies';
@@ -33,5 +34,6 @@ export * from './exceptions/http-exception.factory';
 export * from './exceptions/network.exceptions';
 export * from './exceptions/network-exception.factory';
 export * from './exceptions/unknown.exception';
+export * from './exceptions/validation.exception';
 export * from './exceptions/exception.guards';
 export * from './core/error.converter';

--- a/src/models/request.ts
+++ b/src/models/request.ts
@@ -2,6 +2,7 @@ import { StrUtil } from '../common/utils/str.util';
 import { HttpMethod } from '../common/enums/http-method.enum';
 import { HttpBody } from '../common/types/http.types';
 import { RequestOptions } from './request-options';
+import { ResponseValidator } from '../contracts/response-validator.contract';
 
 /**
  * Represents an immutable HTTP request.
@@ -40,6 +41,7 @@ export class Request {
     public readonly queryParams: Record<string, string> = {},
     public readonly body: HttpBody | null = null,
     public readonly options: RequestOptions = new RequestOptions(),
+    public readonly validators: ResponseValidator[] = [],
   ) {
     this.systemCorrelationId = StrUtil.generateUuid();
     this.timestamp = new Date();

--- a/test/builders/request.builder.spec.ts
+++ b/test/builders/request.builder.spec.ts
@@ -1,5 +1,6 @@
 import { RequestBuilder } from '../../src/builders/request.builder';
 import { HttpMethod } from '../../src/common/enums/http-method.enum';
+import { ResponseValidator } from '../../src/contracts/response-validator.contract';
 
 describe('RequestBuilder', () => {
   let builder: RequestBuilder;
@@ -172,6 +173,42 @@ describe('RequestBuilder', () => {
       // To get coverage, I just need to call them.
       builder.setTimeout(5000);
       builder.setOptions({ timeout: 2000 });
+    });
+  });
+
+  describe('validateWith', () => {
+    const makeValidator = (): ResponseValidator => ({ validate: jest.fn() });
+
+    it('should register a single validator', () => {
+      const validator = makeValidator();
+      const request = builder.validateWith(validator).build();
+      expect(request.validators).toHaveLength(1);
+      expect(request.validators[0]).toBe(validator);
+    });
+
+    it('should register multiple validators passed as rest params', () => {
+      const v1 = makeValidator();
+      const v2 = makeValidator();
+      const request = builder.validateWith(v1, v2).build();
+      expect(request.validators).toHaveLength(2);
+      expect(request.validators[0]).toBe(v1);
+      expect(request.validators[1]).toBe(v2);
+    });
+
+    it('should accumulate validators across multiple calls', () => {
+      const v1 = makeValidator();
+      const v2 = makeValidator();
+      const request = builder.validateWith(v1).validateWith(v2).build();
+      expect(request.validators).toHaveLength(2);
+    });
+
+    it('should default to empty validators array when not called', () => {
+      const request = builder.build();
+      expect(request.validators).toEqual([]);
+    });
+
+    it('should return the builder instance for chaining', () => {
+      expect(builder.validateWith(makeValidator())).toBe(builder);
     });
   });
 });

--- a/test/core/http.adapter.spec.ts
+++ b/test/core/http.adapter.spec.ts
@@ -7,6 +7,7 @@ import { HttpInterceptor } from '../../src/contracts/http-interceptor.contract';
 import { HttpMethod } from '../../src/common/enums/http-method.enum';
 import { defaultHttpClient } from '../../src/core/default-http-client';
 import { HttpClientContract } from '../../src/contracts/http-client.contract';
+import { ValidationException } from '../../src/exceptions/validation.exception';
 
 jest.mock('../../src/core/default-http-client', () => ({
   defaultHttpClient: {
@@ -276,6 +277,206 @@ describe('HttpAdapter', () => {
       const response = await adapter.send(request);
 
       expect(response.headers).toBeNull();
+    });
+
+    it('should run onResponse before validators', async () => {
+      const order: string[] = [];
+      const interceptor = {
+        onResponse: jest.fn().mockImplementation(async (r: Response) => {
+          order.push('onResponse');
+          return r;
+        }),
+      };
+      const validator = { validate: jest.fn().mockImplementation(() => order.push('validator')) };
+
+      const requestWithValidator = new RequestBuilder('https://api.example.com')
+        .setEndpoint('/test')
+        .validateWith(validator)
+        .build();
+
+      adapter = HttpAdapter.create([interceptor], undefined, mockHttpClient);
+      await adapter.send(requestWithValidator);
+
+      expect(order).toEqual(['onResponse', 'validator']);
+    });
+
+    it('should run a single validator after onResponse', async () => {
+      const validator = { validate: jest.fn() };
+      const requestWithValidator = new RequestBuilder('https://api.example.com')
+        .setEndpoint('/test')
+        .validateWith(validator)
+        .build();
+
+      adapter = HttpAdapter.create([], undefined, mockHttpClient);
+      await adapter.send(requestWithValidator);
+
+      expect(validator.validate).toHaveBeenCalledTimes(1);
+      expect(validator.validate).toHaveBeenCalledWith(expect.any(Response));
+    });
+
+    it('should run multiple validators in registration order', async () => {
+      const order: number[] = [];
+      const v1 = { validate: jest.fn().mockImplementation(() => order.push(1)) };
+      const v2 = { validate: jest.fn().mockImplementation(() => order.push(2)) };
+
+      const requestWithValidators = new RequestBuilder('https://api.example.com')
+        .setEndpoint('/test')
+        .validateWith(v1, v2)
+        .build();
+
+      adapter = HttpAdapter.create([], undefined, mockHttpClient);
+      await adapter.send(requestWithValidators);
+
+      expect(order).toEqual([1, 2]);
+    });
+
+    it('should halt validation chain and throw when a validator fails', async () => {
+      const v1 = {
+        validate: jest
+          .fn()
+          .mockRejectedValue(
+            new ValidationException('Invalid status', Response.create({}, 200, null)),
+          ),
+      };
+      const v2 = { validate: jest.fn() };
+
+      const requestWithValidators = new RequestBuilder('https://api.example.com')
+        .setEndpoint('/test')
+        .validateWith(v1, v2)
+        .build();
+
+      adapter = HttpAdapter.create([], undefined, mockHttpClient);
+      await expect(adapter.send(requestWithValidators)).rejects.toBeInstanceOf(ValidationException);
+      expect(v2.validate).not.toHaveBeenCalled();
+    });
+
+    it('should not call validators when request fails with an HTTP error', async () => {
+      mockHttpClient.request.mockRejectedValueOnce({ response: { status: 500, data: {} } });
+
+      const validator = { validate: jest.fn() };
+      const requestWithValidator = new RequestBuilder('https://api.example.com')
+        .setEndpoint('/test')
+        .validateWith(validator)
+        .build();
+
+      adapter = HttpAdapter.create([], undefined, mockHttpClient);
+      await expect(adapter.send(requestWithValidator)).rejects.toBeDefined();
+      expect(validator.validate).not.toHaveBeenCalled();
+    });
+
+    it('should support async validators', async () => {
+      const asyncValidator = { validate: jest.fn().mockResolvedValue(undefined) };
+
+      const requestWithValidator = new RequestBuilder('https://api.example.com')
+        .setEndpoint('/test')
+        .validateWith(asyncValidator)
+        .build();
+
+      adapter = HttpAdapter.create([], undefined, mockHttpClient);
+      await adapter.send(requestWithValidator);
+
+      expect(asyncValidator.validate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onResponseValidated after all validators pass', async () => {
+      const order: string[] = [];
+      const validator = { validate: jest.fn().mockImplementation(() => order.push('validator')) };
+      const interceptor = {
+        onResponseValidated: jest.fn().mockImplementation(async (r: Response) => {
+          order.push('onResponseValidated');
+          return r;
+        }),
+      };
+
+      const requestWithValidator = new RequestBuilder('https://api.example.com')
+        .setEndpoint('/test')
+        .validateWith(validator)
+        .build();
+
+      adapter = HttpAdapter.create([interceptor], undefined, mockHttpClient);
+      await adapter.send(requestWithValidator);
+
+      expect(order).toEqual(['validator', 'onResponseValidated']);
+    });
+
+    it('should not call onResponseValidated when a validator fails', async () => {
+      const interceptor = { onResponseValidated: jest.fn() };
+      const validator = {
+        validate: jest
+          .fn()
+          .mockRejectedValue(new ValidationException('fail', Response.create({}, 200, null))),
+      };
+
+      const requestWithValidator = new RequestBuilder('https://api.example.com')
+        .setEndpoint('/test')
+        .validateWith(validator)
+        .build();
+
+      adapter = HttpAdapter.create([interceptor], undefined, mockHttpClient);
+      await expect(adapter.send(requestWithValidator)).rejects.toBeInstanceOf(ValidationException);
+      expect(interceptor.onResponseValidated).not.toHaveBeenCalled();
+    });
+
+    it('should call onResponse even when validation fails', async () => {
+      const interceptor = {
+        onResponse: jest.fn().mockImplementation(async (r: Response) => r),
+      };
+      const validator = {
+        validate: jest
+          .fn()
+          .mockRejectedValue(new ValidationException('fail', Response.create({}, 200, null))),
+      };
+
+      const requestWithValidator = new RequestBuilder('https://api.example.com')
+        .setEndpoint('/test')
+        .validateWith(validator)
+        .build();
+
+      adapter = HttpAdapter.create([interceptor], undefined, mockHttpClient);
+      await expect(adapter.send(requestWithValidator)).rejects.toBeInstanceOf(ValidationException);
+      expect(interceptor.onResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('should wrap non-BaseAdapterException validator errors in ValidationException', async () => {
+      const zodError = new Error('Schema mismatch');
+      const validator = { validate: jest.fn().mockRejectedValue(zodError) };
+
+      const requestWithValidator = new RequestBuilder('https://api.example.com')
+        .setEndpoint('/test')
+        .validateWith(validator)
+        .build();
+
+      adapter = HttpAdapter.create([], undefined, mockHttpClient);
+      const err = await adapter.send(requestWithValidator).catch((e) => e);
+
+      expect(err).toBeInstanceOf(ValidationException);
+      expect(err.cause).toBe(zodError);
+    });
+
+    it('should not re-wrap BaseAdapterException thrown by a validator', async () => {
+      const validationErr = new ValidationException('explicit', Response.create({}, 200, null));
+      const validator = { validate: jest.fn().mockRejectedValue(validationErr) };
+
+      const requestWithValidator = new RequestBuilder('https://api.example.com')
+        .setEndpoint('/test')
+        .validateWith(validator)
+        .build();
+
+      adapter = HttpAdapter.create([], undefined, mockHttpClient);
+      const err = await adapter.send(requestWithValidator).catch((e) => e);
+
+      expect(err).toBe(validationErr);
+    });
+
+    it('should call onResponseValidated when no validators are registered', async () => {
+      const interceptor = {
+        onResponseValidated: jest.fn().mockImplementation(async (r: Response) => r),
+      };
+
+      adapter = HttpAdapter.create([interceptor], undefined, mockHttpClient);
+      await adapter.send(request);
+
+      expect(interceptor.onResponseValidated).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/test/exceptions/exception.guards.spec.ts
+++ b/test/exceptions/exception.guards.spec.ts
@@ -9,8 +9,11 @@ import {
   isHostUnreachableException,
   isUnknownException,
   isCircuitBreakerOpenException,
+  isValidationException,
 } from '../../src/exceptions/exception.guards';
 import { BaseAdapterException } from '../../src/exceptions/base-adapter.exception';
+import { ValidationException } from '../../src/exceptions/validation.exception';
+import { Response } from '../../src/models/response';
 import { CircuitBreakerOpenException } from '../../src/exceptions/circuit-breaker-open.exception';
 import {
   BadRequestException,
@@ -25,7 +28,6 @@ import {
   HostUnreachableException,
 } from '../../src/exceptions/network.exceptions';
 import { UnknownException } from '../../src/exceptions/unknown.exception';
-import { Response } from '../../src/models/response';
 
 const mockResponse = (status: number) => Response.create(null, status, null);
 
@@ -139,6 +141,18 @@ describe('Exception Type Guards', () => {
     it('returns false for other exceptions', () => {
       expect(isCircuitBreakerOpenException(new UnknownException())).toBe(false);
       expect(isCircuitBreakerOpenException(new Error('plain'))).toBe(false);
+    });
+  });
+
+  describe('isValidationException', () => {
+    it('returns true for ValidationException', () => {
+      const exception = new ValidationException('invalid', Response.create({}, 200, null));
+      expect(isValidationException(exception)).toBe(true);
+    });
+
+    it('returns false for other exceptions', () => {
+      expect(isValidationException(new UnknownException())).toBe(false);
+      expect(isValidationException(new Error('plain'))).toBe(false);
     });
   });
 

--- a/test/exceptions/validation.exception.spec.ts
+++ b/test/exceptions/validation.exception.spec.ts
@@ -1,0 +1,86 @@
+import { BaseAdapterException } from '../../src/exceptions/base-adapter.exception';
+import { ValidationException } from '../../src/exceptions/validation.exception';
+import { Response } from '../../src/models/response';
+
+describe('ValidationException', () => {
+  const makeResponse = () =>
+    Response.create({ status: 'FAILED', message: 'Insufficient funds' }, 200, null, {
+      method: 'POST',
+      url: 'https://api.example.com/payments',
+      correlationId: 'corr-123',
+    });
+
+  it('should set name, message, code, and response', () => {
+    const response = makeResponse();
+    const exception = new ValidationException('Payment failed', response);
+
+    expect(exception.name).toBe('ValidationException');
+    expect(exception.message).toBe('Payment failed');
+    expect(exception.code).toBe('ERR_VALIDATION');
+    expect(exception.response).toBe(response);
+  });
+
+  it('should be an instance of ValidationException and BaseAdapterException', () => {
+    const exception = new ValidationException('fail', makeResponse());
+
+    expect(exception).toBeInstanceOf(ValidationException);
+    expect(exception).toBeInstanceOf(BaseAdapterException);
+  });
+
+  it('should not be retryable', () => {
+    const exception = new ValidationException('fail', makeResponse());
+    expect(exception.isRetryable()).toBe(false);
+  });
+
+  it('should chain cause correctly with default unknown type', () => {
+    const cause = new Error('original');
+    const exception = new ValidationException('fail', makeResponse(), cause);
+    expect(exception.cause).toBe(cause);
+  });
+
+  it('should expose typed cause when generic parameter is provided', () => {
+    class SchemaError extends Error {
+      public readonly issues = [{ message: 'Required field missing' }];
+    }
+    const schemaError = new SchemaError('schema mismatch');
+    const exception = new ValidationException<SchemaError>(
+      'Schema validation failed',
+      makeResponse(),
+      schemaError,
+    );
+
+    expect(exception.cause).toBe(schemaError);
+    expect(exception.cause?.issues[0].message).toBe('Required field missing');
+  });
+
+  it('should have undefined cause when not provided', () => {
+    const exception = new ValidationException('fail', makeResponse());
+    expect(exception.cause).toBeUndefined();
+  });
+
+  it('should serialize to JSON with response details', () => {
+    const response = makeResponse();
+    const exception = new ValidationException('Payment failed', response);
+    const json = exception.toJSON();
+
+    expect(json.name).toBe('ValidationException');
+    expect(json.message).toBe('Payment failed');
+    expect(json.code).toBe('ERR_VALIDATION');
+    expect(json.response).toEqual({
+      status: 200,
+      data: { status: 'FAILED', message: 'Insufficient funds' },
+      request: {
+        method: 'POST',
+        url: 'https://api.example.com/payments',
+        correlationId: 'corr-123',
+      },
+    });
+  });
+
+  it('should be JSON.stringify compatible', () => {
+    const exception = new ValidationException('fail', makeResponse());
+    expect(() => JSON.stringify(exception)).not.toThrow();
+    const parsed = structuredClone(exception.toJSON());
+    expect(parsed.name).toBe('ValidationException');
+  });
+});


### PR DESCRIPTION
- Introduce ResponseValidator<T> interface with sync/async validate() support
- Add ValidationException<TCause> generic exception carrying the original Response and a typed cause; defaults to unknown for backwards-compatible cast-free usage
- Add isValidationException<TCause> type guard consistent with existing guard pattern
- Add RequestBuilder.validateWith(...validators) via rest params with push accumulation
- Store validators on Request model as a readonly array
- Implement validation step in HttpAdapter between onResponse and onResponseValidated: onRequest → HTTP call → onResponse → validators → onResponseValidated → caller
- Add HttpValidatedResponseInterceptor with onResponseValidated hook, fires only when all validators pass; onResponse always fires regardless of validation outcome
- Wrap non-BaseAdapterException validator errors (e.g. ZodError) automatically in ValidationException with original error as cause; BaseAdapterException re-thrown as-is
- Bump version to 3.2.0
- Update CHANGELOG, README (EN/TR) with lifecycle diagram, generic cause usage, and onResponseValidated documentation
- 334 tests passing with 100% coverage