### PR TITLE
feat: expand retry policies with jitter strategies and RetryPredicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2026-03-26
+
+### Added
+
+- **`RetryPredicate` Interface**: A pluggable contract for overriding the retry decision. Implement `shouldRetry(error: BaseAdapterException): boolean` to encapsulate complex conditions (e.g. combining `isRetryable()` with circuit state or feature flags).
+- **`RetryPolicy.retryIf(predicate)`**: New method on the base `RetryPolicy` class that accepts either a `RetryPredicate` instance or a plain `(error: BaseAdapterException) => boolean` function. Returns the policy for chaining. When not called, the default behaviour (`error.isRetryable()`) is preserved.
+- **`RetryPolicies.fixedDelay(attempts, delayMs)`**: New policy — identical wait time between every retry attempt.
+- **`RetryPolicies.linearBackoff(attempts, stepMs)`**: New policy — wait time grows linearly (`attempt * stepMs`).
+- **`RetryPolicies.fullJitter(attempts, baseMs)`**: New policy — fully randomised delay within an exponential cap (`random(0, 2^attempt * baseMs)`). Best choice for spreading load across many concurrent clients.
+- **`RetryPolicies.decorrelatedJitter(attempts, baseMs, maxDelayMs)`**: New policy — each delay is derived from the previous one (`random(baseMs, prevDelay * 3)`), capped at `maxDelayMs`. Provides the widest spread for high-concurrency scenarios (AWS-recommended algorithm).
+- **`retryOn` moved to base class**: All policies now share the same retry decision logic in `RetryPolicy`, delegating to the `retryIf` predicate when set, or `error.isRetryable()` by default.
+
 ## [3.5.0] - 2026-03-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -334,15 +334,46 @@ export class GlobalErrorInterceptor implements HttpErrorInterceptor {
 
 Network instability is inevitable. This adapter allows you to define robust retry strategies.
 
-### Exponential Backoff
+### Built-in Retry Policies
 
-The built-in `ExponentialBackoffPolicy` waits increasingly longer between retries (e.g., 200ms, 400ms, 800ms) and adds random jitter to prevent "thundering herd" issues.
+| Policy | Factory | Behaviour |
+|---|---|---|
+| Exponential Backoff | `RetryPolicies.exponential(attempts)` | Delay doubles with each attempt plus small jitter — default choice |
+| Fixed Delay | `RetryPolicies.fixedDelay(attempts, delayMs)` | Constant wait between every retry |
+| Linear Backoff | `RetryPolicies.linearBackoff(attempts, stepMs)` | Delay grows linearly (`attempt × stepMs`) |
+| Full Jitter | `RetryPolicies.fullJitter(attempts, baseMs)` | Fully random delay within exponential cap — best for spreading concurrent load |
+| Decorrelated Jitter | `RetryPolicies.decorrelatedJitter(attempts, baseMs, maxDelayMs)` | AWS-recommended algorithm with widest spread across concurrent clients |
 
 ```typescript
 import { RetryPolicies } from '@yildizpay/http-adapter';
 
-// Retries on 429, 502, 503, 504 and network errors
-const retryPolicy = RetryPolicies.exponential(5);
+// All policies retry on 429, 502, 503, 504 and network errors by default
+RetryPolicies.exponential(3);
+RetryPolicies.fixedDelay(3, 1000);          // 1 s between each attempt
+RetryPolicies.linearBackoff(3, 500);        // 500 ms, 1000 ms, 1500 ms
+RetryPolicies.fullJitter(3, 100);           // random within [0, 2^attempt * 100 ms]
+RetryPolicies.decorrelatedJitter(3, 100);   // AWS decorrelated jitter, cap 30 s
+```
+
+### Custom Retry Predicate
+
+Override the default retry decision (`error.isRetryable()`) for any policy via `retryIf()`. Accepts a plain function or a class implementing `RetryPredicate`.
+
+```typescript
+import { RetryPolicies, RetryPredicate, BaseAdapterException, isNetworkException } from '@yildizpay/http-adapter';
+
+// Inline function
+const policy = RetryPolicies.exponential(3)
+  .retryIf((error) => isNetworkException(error));
+
+// Class-based predicate
+class BusinessRetryPredicate implements RetryPredicate {
+  shouldRetry(error: BaseAdapterException): boolean {
+    return error.isRetryable() && myCircuitIsAllowing();
+  }
+}
+
+const policy = RetryPolicies.fullJitter(3).retryIf(new BusinessRetryPredicate());
 ```
 
 ### Circuit Breaker

--- a/README.tr.md
+++ b/README.tr.md
@@ -334,15 +334,46 @@ export class GlobalErrorInterceptor implements HttpErrorInterceptor {
 
 Ağ kararsızlığı kaçınılmazdır. Bu adaptör, sağlam retry stratejileri tanımlamanıza olanak tanır.
 
-### Exponential Backoff
+### Built-in Retry Policy'ler
 
-Built-in `ExponentialBackoffPolicy`, denemeler arasında giderek artan süreler (ör. 200ms, 400ms, 800ms) bekler ve "thundering herd" sorununu önlemek için gecikmelere rastgele jitter ekler.
+| Policy | Factory | Davranış |
+|---|---|---|
+| Exponential Backoff | `RetryPolicies.exponential(attempts)` | Her denemede gecikme iki katına çıkar, küçük jitter eklenir — varsayılan seçim |
+| Fixed Delay | `RetryPolicies.fixedDelay(attempts, delayMs)` | Her retry arasında sabit bekleme süresi |
+| Linear Backoff | `RetryPolicies.linearBackoff(attempts, stepMs)` | Gecikme doğrusal büyür (`attempt × stepMs`) |
+| Full Jitter | `RetryPolicies.fullJitter(attempts, baseMs)` | Üstel cap içinde tamamen rastgele gecikme — concurrent yükü yaymak için en iyi seçim |
+| Decorrelated Jitter | `RetryPolicies.decorrelatedJitter(attempts, baseMs, maxDelayMs)` | AWS tarafından önerilen algoritma, concurrent istemciler arasında en geniş yayılımı sağlar |
 
 ```typescript
 import { RetryPolicies } from '@yildizpay/http-adapter';
 
-// 429, 502, 503, 504 ve ağ hatalarında retry yapar
-const retryPolicy = RetryPolicies.exponential(5);
+// Tüm policy'ler varsayılan olarak 429, 502, 503, 504 ve ağ hatalarında retry yapar
+RetryPolicies.exponential(3);
+RetryPolicies.fixedDelay(3, 1000);          // her denemede 1 sn bekleme
+RetryPolicies.linearBackoff(3, 500);        // 500 ms, 1000 ms, 1500 ms
+RetryPolicies.fullJitter(3, 100);           // [0, 2^attempt * 100 ms] aralığında rastgele
+RetryPolicies.decorrelatedJitter(3, 100);   // AWS decorrelated jitter, cap 30 sn
+```
+
+### Özel Retry Predicate
+
+`retryIf()` ile herhangi bir policy'nin varsayılan retry kararını (`error.isRetryable()`) override edebilirsiniz. Düz bir fonksiyon ya da `RetryPredicate` interface'ini implement eden bir sınıf kabul eder.
+
+```typescript
+import { RetryPolicies, RetryPredicate, BaseAdapterException, isNetworkException } from '@yildizpay/http-adapter';
+
+// Inline fonksiyon
+const policy = RetryPolicies.exponential(3)
+  .retryIf((error) => isNetworkException(error));
+
+// Sınıf tabanlı predicate
+class BusinessRetryPredicate implements RetryPredicate {
+  shouldRetry(error: BaseAdapterException): boolean {
+    return error.isRetryable() && myCircuitIsAllowing();
+  }
+}
+
+const policy = RetryPolicies.fullJitter(3).retryIf(new BusinessRetryPredicate());
 ```
 
 ### Circuit Breaker

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yildizpay/http-adapter",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Enterprise-grade, zero-dependency HTTP adapter for Node.js with pluggable client abstractions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/contracts/retry-policy.contract.ts
+++ b/src/contracts/retry-policy.contract.ts
@@ -1,14 +1,60 @@
+import { BaseAdapterException } from '../exceptions/base-adapter.exception';
+import { RetryPredicate } from './retry-predicate.contract';
+
 /**
  * Defines the contract for an HTTP retry policy.
  *
- * Subclasses should implement specific retry strategies, such as exponential backoff,
- * constant delay, or custom logic to determine when and how to retry failed requests.
+ * Subclasses implement the backoff timing strategy (`backoffMs`). The retry decision
+ * defaults to `BaseAdapterException.isRetryable()` but can be overridden per-instance
+ * via `retryIf()`.
  */
 export abstract class RetryPolicy {
   /**
    * The maximum number of retry attempts allowed.
    */
   public abstract maxAttempts: number;
+
+  private predicate: RetryPredicate | undefined;
+
+  /**
+   * Overrides the default retry decision for this policy instance.
+   *
+   * Accepts either a `RetryPredicate` instance (for complex, class-based logic)
+   * or a plain function (for simple inline conditions).
+   *
+   * When not called, the default behaviour is to retry whenever
+   * `error.isRetryable()` returns `true`.
+   *
+   * @param predicate - A `RetryPredicate` or `(error: BaseAdapterException) => boolean`.
+   * @returns The current policy instance for method chaining.
+   *
+   * @example
+   * ```typescript
+   * // Simple function
+   * RetryPolicies.exponential(3).retryIf((err) => isNetworkError(err))
+   *
+   * // Class-based predicate
+   * RetryPolicies.exponential(3).retryIf(new BusinessRetryPredicate())
+   * ```
+   */
+  public retryIf(predicate: RetryPredicate | ((error: BaseAdapterException) => boolean)): this {
+    this.predicate = typeof predicate === 'function' ? { shouldRetry: predicate } : predicate;
+    return this;
+  }
+
+  /**
+   * Determines whether a retry should be attempted based on the error received.
+   *
+   * Delegates to the custom predicate set via `retryIf()` if present,
+   * otherwise falls back to `error.isRetryable()`.
+   *
+   * @param error - The error encountered during the request.
+   * @returns `true` if the request should be retried; otherwise `false`.
+   */
+  public retryOn(error: unknown): boolean {
+    if (!(error instanceof BaseAdapterException)) return false;
+    return this.predicate ? this.predicate.shouldRetry(error) : error.isRetryable();
+  }
 
   /**
    * Calculates the delay in milliseconds before the next retry attempt.
@@ -17,12 +63,4 @@ export abstract class RetryPolicy {
    * @returns The delay duration in milliseconds.
    */
   public abstract backoffMs(attempt: number): number;
-
-  /**
-   * Determines whether a retry should be attempted based on the error received.
-   *
-   * @param error - The error encountered during the request.
-   * @returns `true` if the request should be retried; otherwise, `false`.
-   */
-  public abstract retryOn(error: unknown): boolean;
 }

--- a/src/contracts/retry-predicate.contract.ts
+++ b/src/contracts/retry-predicate.contract.ts
@@ -1,0 +1,25 @@
+import { BaseAdapterException } from '../exceptions/base-adapter.exception';
+
+/**
+ * Defines a pluggable predicate for determining whether a failed request should be retried.
+ *
+ * Implement this interface to encapsulate complex retry conditions — for example,
+ * combining `isRetryable()` with circuit state, feature flags, or domain-specific rules.
+ *
+ * For simple cases, a plain function `(error: BaseAdapterException) => boolean` can be
+ * passed directly to `retryIf()` instead.
+ *
+ * @example
+ * ```typescript
+ * class BusinessRetryPredicate implements RetryPredicate {
+ *   shouldRetry(error: BaseAdapterException): boolean {
+ *     return error.isRetryable() && circuitState.isHealthy();
+ *   }
+ * }
+ *
+ * RetryPolicies.exponential(3).retryIf(new BusinessRetryPredicate())
+ * ```
+ */
+export interface RetryPredicate {
+  shouldRetry(error: BaseAdapterException): boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,16 @@ export * from './models/correlation-id-config';
 // Contracts
 export * from './contracts/http-interceptor.contract';
 export * from './contracts/retry-policy.contract';
+export * from './contracts/retry-predicate.contract';
 export * from './contracts/response-validator.contract';
 
 // Resilience
 export * from './resilience/retry.policies';
+export * from './resilience/policies/exponential-backoff.retry-policy';
+export * from './resilience/policies/fixed-delay.retry-policy';
+export * from './resilience/policies/linear-backoff.retry-policy';
+export * from './resilience/policies/full-jitter.retry-policy';
+export * from './resilience/policies/decorrelated-jitter.retry-policy';
 export * from './resilience/circuit-breaker/circuit-state.enum';
 export * from './resilience/circuit-breaker/circuit-breaker-options';
 export * from './resilience/circuit-breaker/circuit-breaker';

--- a/src/resilience/policies/decorrelated-jitter.retry-policy.ts
+++ b/src/resilience/policies/decorrelated-jitter.retry-policy.ts
@@ -1,0 +1,31 @@
+import { RetryPolicy } from '../../contracts/retry-policy.contract';
+
+/**
+ * A retry policy that uses the decorrelated jitter algorithm.
+ *
+ * Wait time formula: `random(baseMs, min(maxDelayMs, baseMs * 3^attempt))`.
+ * The upper bound grows with each attempt, providing a wider spread and better
+ * decorrelation between concurrent clients without relying on mutable state.
+ *
+ * Reference: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+ *
+ * @example
+ * ```typescript
+ * RetryPolicies.decorrelatedJitter(3)
+ * RetryPolicies.decorrelatedJitter(3, 100, 30000) // custom base and cap
+ * ```
+ */
+export class DecorrelatedJitterPolicy extends RetryPolicy {
+  constructor(
+    public maxAttempts: number = 3,
+    private readonly baseMs: number = 100,
+    private readonly maxDelayMs: number = 30000,
+  ) {
+    super();
+  }
+
+  public backoffMs(attempt: number): number {
+    const cap = Math.min(this.maxDelayMs, this.baseMs * Math.pow(3, attempt));
+    return Math.random() * (cap - this.baseMs) + this.baseMs;
+  }
+}

--- a/src/resilience/policies/exponential-backoff.retry-policy.ts
+++ b/src/resilience/policies/exponential-backoff.retry-policy.ts
@@ -1,46 +1,16 @@
 import { RetryPolicy } from '../../contracts/retry-policy.contract';
-import { BaseAdapterException } from '../../exceptions/base-adapter.exception';
 
 /**
- * A retry policy that implements an exponential backoff strategy.
+ * A retry policy that uses exponential backoff with added jitter.
  *
- * This strategy increases the wait time between retries exponentially (2^attempt)
- * to reduce load on the failing service. It also includes a random jitter to prevent
- * thundering herd problems.
+ * Wait time formula: `(2^attempt * 100) + random(0–50) ms`.
+ * The jitter prevents thundering herd problems when many clients retry simultaneously.
  */
 export class ExponentialBackoffPolicy extends RetryPolicy {
-  /**
-   * Initializes a new instance of the ExponentialBackoffPolicy class.
-   *
-   * @param maxAttempts - The maximum number of retry attempts (default: 3).
-   */
   constructor(public maxAttempts: number = 3) {
     super();
-    this.maxAttempts = maxAttempts;
   }
 
-  /**
-   * Determines if the operation should be retried based on the error.
-   *
-   * Delegates the decision to {@link BaseAdapterException.isRetryable}, which encodes
-   * the retryability contract for every exception in the hierarchy. Non-adapter errors
-   * (i.e. anything not converted by `ErrorConverter`) are never retried.
-   *
-   * @param error - The error encountered.
-   * @returns `true` if the error is retryable; otherwise `false`.
-   */
-  public retryOn(error: unknown): boolean {
-    return error instanceof BaseAdapterException && error.isRetryable();
-  }
-
-  /**
-   * Calculates the delay before the next retry attempt using exponential backoff with jitter.
-   *
-   * Formula: (2^attempt * 100) + random(0-50) ms.
-   *
-   * @param attempt - The current attempt number.
-   * @returns The delay duration in milliseconds.
-   */
   public backoffMs(attempt: number): number {
     const base = Math.pow(2, attempt) * 100;
     const jitter = Math.random() * 50;

--- a/src/resilience/policies/fixed-delay.retry-policy.ts
+++ b/src/resilience/policies/fixed-delay.retry-policy.ts
@@ -1,0 +1,25 @@
+import { RetryPolicy } from '../../contracts/retry-policy.contract';
+
+/**
+ * A retry policy that waits a fixed amount of time between every attempt.
+ *
+ * Suitable for predictable, low-frequency retry scenarios where a constant
+ * cooldown period is preferred over increasing delays.
+ *
+ * @example
+ * ```typescript
+ * RetryPolicies.fixedDelay(3, 1000) // 3 attempts, 1 s between each
+ * ```
+ */
+export class FixedDelayPolicy extends RetryPolicy {
+  constructor(
+    public maxAttempts: number = 3,
+    private readonly delayMs: number = 1000,
+  ) {
+    super();
+  }
+
+  public backoffMs(_attempt: number): number {
+    return this.delayMs;
+  }
+}

--- a/src/resilience/policies/full-jitter.retry-policy.ts
+++ b/src/resilience/policies/full-jitter.retry-policy.ts
@@ -1,0 +1,30 @@
+import { RetryPolicy } from '../../contracts/retry-policy.contract';
+
+/**
+ * A retry policy that uses exponential backoff with full jitter.
+ *
+ * Wait time formula: `random(0, 2^attempt * baseMs)`.
+ * The delay is fully randomised within the exponential cap, which provides
+ * the best spread when many clients retry simultaneously.
+ *
+ * Reference: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+ *
+ * @example
+ * ```typescript
+ * RetryPolicies.fullJitter(3)
+ * RetryPolicies.fullJitter(3, 200) // custom base
+ * ```
+ */
+export class FullJitterPolicy extends RetryPolicy {
+  constructor(
+    public maxAttempts: number = 3,
+    private readonly baseMs: number = 100,
+  ) {
+    super();
+  }
+
+  public backoffMs(attempt: number): number {
+    const cap = Math.pow(2, attempt) * this.baseMs;
+    return Math.random() * cap;
+  }
+}

--- a/src/resilience/policies/linear-backoff.retry-policy.ts
+++ b/src/resilience/policies/linear-backoff.retry-policy.ts
@@ -1,0 +1,24 @@
+import { RetryPolicy } from '../../contracts/retry-policy.contract';
+
+/**
+ * A retry policy that increases the wait time linearly with each attempt.
+ *
+ * Wait time formula: `attempt * stepMs`.
+ *
+ * @example
+ * ```typescript
+ * RetryPolicies.linearBackoff(3, 500) // 500 ms, 1000 ms, 1500 ms
+ * ```
+ */
+export class LinearBackoffPolicy extends RetryPolicy {
+  constructor(
+    public maxAttempts: number = 3,
+    private readonly stepMs: number = 500,
+  ) {
+    super();
+  }
+
+  public backoffMs(attempt: number): number {
+    return attempt * this.stepMs;
+  }
+}

--- a/src/resilience/retry.policies.ts
+++ b/src/resilience/retry.policies.ts
@@ -1,19 +1,73 @@
 import { ExponentialBackoffPolicy } from './policies/exponential-backoff.retry-policy';
+import { FixedDelayPolicy } from './policies/fixed-delay.retry-policy';
+import { LinearBackoffPolicy } from './policies/linear-backoff.retry-policy';
+import { FullJitterPolicy } from './policies/full-jitter.retry-policy';
+import { DecorrelatedJitterPolicy } from './policies/decorrelated-jitter.retry-policy';
 
 /**
  * A factory class for creating standard retry policies.
  *
- * Provides static methods to easily instantiate common retry strategies without
- * needing to manually construct policy classes.
+ * Every method returns a policy instance that can be further customised
+ * with `.retryIf()` to override the default retry predicate.
  */
 export class RetryPolicies {
   /**
-   * Creates an exponential backoff retry policy.
+   * Exponential backoff with light jitter.
+   * Formula: `(2^attempt * 100) + random(0–50) ms`.
    *
-   * @param attempts - The maximum number of retry attempts (default: 3).
-   * @returns A new instance of `ExponentialBackoffPolicy`.
+   * @param attempts - Maximum retry attempts (default: 3).
    */
-  static exponential(attempts = 3) {
+  static exponential(attempts = 3): ExponentialBackoffPolicy {
     return new ExponentialBackoffPolicy(attempts);
+  }
+
+  /**
+   * Fixed delay — identical wait time between every attempt.
+   *
+   * @param attempts - Maximum retry attempts (default: 3).
+   * @param delayMs - Wait time in milliseconds (default: 1000).
+   */
+  static fixedDelay(attempts = 3, delayMs = 1000): FixedDelayPolicy {
+    return new FixedDelayPolicy(attempts, delayMs);
+  }
+
+  /**
+   * Linear backoff — wait time grows by a fixed step each attempt.
+   * Formula: `attempt * stepMs`.
+   *
+   * @param attempts - Maximum retry attempts (default: 3).
+   * @param stepMs - Step size in milliseconds (default: 500).
+   */
+  static linearBackoff(attempts = 3, stepMs = 500): LinearBackoffPolicy {
+    return new LinearBackoffPolicy(attempts, stepMs);
+  }
+
+  /**
+   * Full jitter — fully randomised delay within an exponential cap.
+   * Formula: `random(0, 2^attempt * baseMs)`.
+   * Best choice for spreading load across many concurrent clients.
+   *
+   * @param attempts - Maximum retry attempts (default: 3).
+   * @param baseMs - Base multiplier in milliseconds (default: 100).
+   */
+  static fullJitter(attempts = 3, baseMs = 100): FullJitterPolicy {
+    return new FullJitterPolicy(attempts, baseMs);
+  }
+
+  /**
+   * Decorrelated jitter — each delay is derived from the previous one.
+   * Formula: `random(baseMs, prevDelay * 3)`, capped at `maxDelayMs`.
+   * Provides the widest spread and best decorrelation for high-concurrency scenarios.
+   *
+   * @param attempts - Maximum retry attempts (default: 3).
+   * @param baseMs - Minimum delay in milliseconds (default: 100).
+   * @param maxDelayMs - Maximum delay cap in milliseconds (default: 30000).
+   */
+  static decorrelatedJitter(
+    attempts = 3,
+    baseMs = 100,
+    maxDelayMs = 30000,
+  ): DecorrelatedJitterPolicy {
+    return new DecorrelatedJitterPolicy(attempts, baseMs, maxDelayMs);
   }
 }

--- a/test/contracts/retry-policy.contract.spec.ts
+++ b/test/contracts/retry-policy.contract.spec.ts
@@ -1,0 +1,99 @@
+import { RetryPolicy } from '../../src/contracts/retry-policy.contract';
+import { HttpExceptionFactory } from '../../src/exceptions/http-exception.factory';
+import { TimeoutException } from '../../src/exceptions/network.exceptions';
+import { NotFoundException } from '../../src/exceptions/http-status.exceptions';
+import { RetryPredicate } from '../../src/contracts/retry-predicate.contract';
+import { BaseAdapterException } from '../../src/exceptions/base-adapter.exception';
+
+class TestPolicy extends RetryPolicy {
+  maxAttempts = 3;
+  backoffMs(): number {
+    return 0;
+  }
+}
+
+describe('RetryPolicy', () => {
+  let policy: TestPolicy;
+
+  beforeEach(() => {
+    policy = new TestPolicy();
+  });
+
+  describe('retryOn (default behaviour)', () => {
+    it('should return true for a retryable BaseAdapterException', () => {
+      expect(policy.retryOn(HttpExceptionFactory.createFromResponse(429))).toBe(true);
+    });
+
+    it('should return false for a non-retryable BaseAdapterException', () => {
+      expect(policy.retryOn(HttpExceptionFactory.createFromResponse(404))).toBe(false);
+    });
+
+    it('should return false for a non-adapter error', () => {
+      expect(policy.retryOn(new Error('generic'))).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      expect(policy.retryOn(null)).toBe(false);
+    });
+  });
+
+  describe('retryIf with function predicate', () => {
+    it('should use the provided function instead of isRetryable()', () => {
+      policy.retryIf(() => true);
+      expect(policy.retryOn(HttpExceptionFactory.createFromResponse(404))).toBe(true);
+    });
+
+    it('should pass the error to the predicate function', () => {
+      const received: BaseAdapterException[] = [];
+      const err = new TimeoutException();
+      policy.retryIf((e) => {
+        received.push(e);
+        return false;
+      });
+      policy.retryOn(err);
+      expect(received[0]).toBe(err);
+    });
+
+    it('should return false when predicate function returns false', () => {
+      policy.retryIf(() => false);
+      expect(policy.retryOn(HttpExceptionFactory.createFromResponse(429))).toBe(false);
+    });
+
+    it('should not call the predicate for non-adapter errors', () => {
+      const predicate = jest.fn(() => true);
+      policy.retryIf(predicate);
+      policy.retryOn(new Error('plain'));
+      expect(predicate).not.toHaveBeenCalled();
+    });
+
+    it('should return the policy instance for chaining', () => {
+      expect(policy.retryIf(() => true)).toBe(policy);
+    });
+  });
+
+  describe('retryIf with RetryPredicate instance', () => {
+    it('should delegate to shouldRetry on the predicate instance', () => {
+      const predicate: RetryPredicate = { shouldRetry: () => true };
+      policy.retryIf(predicate);
+      expect(
+        policy.retryOn(
+          new NotFoundException(HttpExceptionFactory.createFromResponse(404) as any, ''),
+        ),
+      ).toBe(true);
+    });
+
+    it('should pass the error to shouldRetry', () => {
+      const received: BaseAdapterException[] = [];
+      const err = new TimeoutException();
+      const predicate: RetryPredicate = {
+        shouldRetry: (e) => {
+          received.push(e);
+          return true;
+        },
+      };
+      policy.retryIf(predicate);
+      policy.retryOn(err);
+      expect(received[0]).toBe(err);
+    });
+  });
+});

--- a/test/core/http.adapter.spec.ts
+++ b/test/core/http.adapter.spec.ts
@@ -8,6 +8,7 @@ import { HttpMethod } from '../../src/common/enums/http-method.enum';
 import { defaultHttpClient } from '../../src/core/default-http-client';
 import { HttpClientContract } from '../../src/contracts/http-client.contract';
 import { ValidationException } from '../../src/exceptions/validation.exception';
+import { RetryPolicies } from '../../src/resilience/retry.policies';
 
 jest.mock('../../src/core/default-http-client', () => ({
   defaultHttpClient: {
@@ -188,11 +189,7 @@ describe('HttpAdapter', () => {
     });
 
     it('should use retry policy calls when provided', async () => {
-      const mockRetryPolicy = {
-        maxAttempts: 3,
-        retryOn: jest.fn().mockReturnValue(false),
-        backoffMs: jest.fn().mockReturnValue(0),
-      };
+      const mockRetryPolicy = RetryPolicies.exponential(3);
 
       adapter = HttpAdapter.create([], mockRetryPolicy, mockHttpClient);
 

--- a/test/resilience/policies/decorrelated-jitter.retry-policy.spec.ts
+++ b/test/resilience/policies/decorrelated-jitter.retry-policy.spec.ts
@@ -1,0 +1,39 @@
+import { DecorrelatedJitterPolicy } from '../../../src/resilience/policies/decorrelated-jitter.retry-policy';
+
+describe('DecorrelatedJitterPolicy', () => {
+  it('should return a delay >= baseMs', () => {
+    const policy = new DecorrelatedJitterPolicy(3, 100);
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      expect(policy.backoffMs(attempt)).toBeGreaterThanOrEqual(100);
+    }
+  });
+
+  it('should never exceed maxDelayMs', () => {
+    const policy = new DecorrelatedJitterPolicy(10, 100, 500);
+    for (let attempt = 1; attempt <= 10; attempt++) {
+      expect(policy.backoffMs(attempt)).toBeLessThanOrEqual(500);
+    }
+  });
+
+  it('should use default baseMs of 100 and maxDelayMs of 30000', () => {
+    const policy = new DecorrelatedJitterPolicy();
+    const delay = policy.backoffMs(1);
+    expect(delay).toBeGreaterThanOrEqual(100);
+    expect(delay).toBeLessThanOrEqual(30000);
+  });
+
+  it('should use default maxAttempts of 3', () => {
+    expect(new DecorrelatedJitterPolicy().maxAttempts).toBe(3);
+  });
+
+  it('should allow overriding maxAttempts', () => {
+    expect(new DecorrelatedJitterPolicy(5).maxAttempts).toBe(5);
+  });
+
+  it('should produce different delays across calls (probabilistic)', () => {
+    const policy = new DecorrelatedJitterPolicy(3, 100, 30000);
+    const delays = Array.from({ length: 10 }, () => policy.backoffMs(3));
+    const unique = new Set(delays);
+    expect(unique.size).toBeGreaterThan(1);
+  });
+});

--- a/test/resilience/policies/exponential-backoff.retry-policy.spec.ts
+++ b/test/resilience/policies/exponential-backoff.retry-policy.spec.ts
@@ -1,13 +1,4 @@
 import { ExponentialBackoffPolicy } from '../../../src/resilience/policies/exponential-backoff.retry-policy';
-import { HttpExceptionFactory } from '../../../src/exceptions/http-exception.factory';
-import {
-  TimeoutException,
-  ConnectionRefusedException,
-  SocketResetException,
-  DnsResolutionException,
-  HostUnreachableException,
-} from '../../../src/exceptions/network.exceptions';
-import { UnknownException } from '../../../src/exceptions/unknown.exception';
 
 describe('ExponentialBackoffPolicy', () => {
   let policy: ExponentialBackoffPolicy;
@@ -16,77 +7,20 @@ describe('ExponentialBackoffPolicy', () => {
     policy = new ExponentialBackoffPolicy();
   });
 
-  describe('retryOn', () => {
-    const retryableStatuses = [429, 502, 503, 504];
-    const nonRetryableStatuses = [400, 401, 403, 404, 422, 500];
-
-    retryableStatuses.forEach((status) => {
-      it(`should return true for HTTP ${status}`, () => {
-        expect(policy.retryOn(HttpExceptionFactory.createFromResponse(status))).toBe(true);
-      });
-    });
-
-    nonRetryableStatuses.forEach((status) => {
-      it(`should return false for HTTP ${status}`, () => {
-        expect(policy.retryOn(HttpExceptionFactory.createFromResponse(status))).toBe(false);
-      });
-    });
-
-    it('should return true for TimeoutException', () => {
-      expect(policy.retryOn(new TimeoutException())).toBe(true);
-    });
-
-    it('should return true for ConnectionRefusedException', () => {
-      expect(policy.retryOn(new ConnectionRefusedException())).toBe(true);
-    });
-
-    it('should return true for SocketResetException', () => {
-      expect(policy.retryOn(new SocketResetException())).toBe(true);
-    });
-
-    it('should return false for DnsResolutionException', () => {
-      expect(policy.retryOn(new DnsResolutionException())).toBe(false);
-    });
-
-    it('should return false for HostUnreachableException', () => {
-      expect(policy.retryOn(new HostUnreachableException())).toBe(false);
-    });
-
-    it('should return false for UnknownException', () => {
-      expect(policy.retryOn(new UnknownException())).toBe(false);
-    });
-
-    it('should return false for plain Error', () => {
-      expect(policy.retryOn(new Error('generic'))).toBe(false);
-    });
-
-    it('should return false for null', () => {
-      expect(policy.retryOn(null)).toBe(false);
-    });
-
-    it('should return false for string', () => {
-      expect(policy.retryOn('string error')).toBe(false);
-    });
-
-    it('should return false for raw status object (not a BaseAdapterException)', () => {
-      expect(policy.retryOn({ response: { status: 503 } })).toBe(false);
-    });
-  });
-
   describe('backoffMs', () => {
-    it('should calculate delay within expected range for attempt 1', () => {
+    it('should return delay within expected range for attempt 1', () => {
       const delay = policy.backoffMs(1);
       expect(delay).toBeGreaterThanOrEqual(200);
       expect(delay).toBeLessThanOrEqual(250);
     });
 
-    it('should calculate delay within expected range for attempt 2', () => {
+    it('should return delay within expected range for attempt 2', () => {
       const delay = policy.backoffMs(2);
       expect(delay).toBeGreaterThanOrEqual(400);
       expect(delay).toBeLessThanOrEqual(450);
     });
 
-    it('should calculate delay within expected range for attempt 3', () => {
+    it('should return delay within expected range for attempt 3', () => {
       const delay = policy.backoffMs(3);
       expect(delay).toBeGreaterThanOrEqual(800);
       expect(delay).toBeLessThanOrEqual(850);
@@ -99,8 +33,7 @@ describe('ExponentialBackoffPolicy', () => {
     });
 
     it('should allow overriding maxAttempts', () => {
-      const customPolicy = new ExponentialBackoffPolicy(5);
-      expect(customPolicy.maxAttempts).toBe(5);
+      expect(new ExponentialBackoffPolicy(5).maxAttempts).toBe(5);
     });
   });
 });

--- a/test/resilience/policies/fixed-delay.retry-policy.spec.ts
+++ b/test/resilience/policies/fixed-delay.retry-policy.spec.ts
@@ -1,0 +1,23 @@
+import { FixedDelayPolicy } from '../../../src/resilience/policies/fixed-delay.retry-policy';
+
+describe('FixedDelayPolicy', () => {
+  it('should return the configured delay on every attempt', () => {
+    const policy = new FixedDelayPolicy(3, 2000);
+    expect(policy.backoffMs(1)).toBe(2000);
+    expect(policy.backoffMs(2)).toBe(2000);
+    expect(policy.backoffMs(3)).toBe(2000);
+  });
+
+  it('should use default delay of 1000 ms', () => {
+    const policy = new FixedDelayPolicy();
+    expect(policy.backoffMs(1)).toBe(1000);
+  });
+
+  it('should use default maxAttempts of 3', () => {
+    expect(new FixedDelayPolicy().maxAttempts).toBe(3);
+  });
+
+  it('should allow overriding maxAttempts', () => {
+    expect(new FixedDelayPolicy(5).maxAttempts).toBe(5);
+  });
+});

--- a/test/resilience/policies/full-jitter.retry-policy.spec.ts
+++ b/test/resilience/policies/full-jitter.retry-policy.spec.ts
@@ -1,0 +1,35 @@
+import { FullJitterPolicy } from '../../../src/resilience/policies/full-jitter.retry-policy';
+
+describe('FullJitterPolicy', () => {
+  it('should return a delay within [0, 2^attempt * baseMs]', () => {
+    const policy = new FullJitterPolicy(3, 100);
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      const delay = policy.backoffMs(attempt);
+      const cap = Math.pow(2, attempt) * 100;
+      expect(delay).toBeGreaterThanOrEqual(0);
+      expect(delay).toBeLessThan(cap);
+    }
+  });
+
+  it('should use default baseMs of 100', () => {
+    const policy = new FullJitterPolicy();
+    const delay = policy.backoffMs(1);
+    expect(delay).toBeGreaterThanOrEqual(0);
+    expect(delay).toBeLessThan(200);
+  });
+
+  it('should use default maxAttempts of 3', () => {
+    expect(new FullJitterPolicy().maxAttempts).toBe(3);
+  });
+
+  it('should allow overriding maxAttempts', () => {
+    expect(new FullJitterPolicy(5).maxAttempts).toBe(5);
+  });
+
+  it('should produce different delays across calls (probabilistic)', () => {
+    const policy = new FullJitterPolicy(3, 100);
+    const delays = Array.from({ length: 10 }, () => policy.backoffMs(3));
+    const unique = new Set(delays);
+    expect(unique.size).toBeGreaterThan(1);
+  });
+});

--- a/test/resilience/policies/linear-backoff.retry-policy.spec.ts
+++ b/test/resilience/policies/linear-backoff.retry-policy.spec.ts
@@ -1,0 +1,23 @@
+import { LinearBackoffPolicy } from '../../../src/resilience/policies/linear-backoff.retry-policy';
+
+describe('LinearBackoffPolicy', () => {
+  it('should return attempt * stepMs on each attempt', () => {
+    const policy = new LinearBackoffPolicy(3, 500);
+    expect(policy.backoffMs(1)).toBe(500);
+    expect(policy.backoffMs(2)).toBe(1000);
+    expect(policy.backoffMs(3)).toBe(1500);
+  });
+
+  it('should use default stepMs of 500', () => {
+    const policy = new LinearBackoffPolicy();
+    expect(policy.backoffMs(2)).toBe(1000);
+  });
+
+  it('should use default maxAttempts of 3', () => {
+    expect(new LinearBackoffPolicy().maxAttempts).toBe(3);
+  });
+
+  it('should allow overriding maxAttempts', () => {
+    expect(new LinearBackoffPolicy(5).maxAttempts).toBe(5);
+  });
+});

--- a/test/resilience/retry.policies.spec.ts
+++ b/test/resilience/retry.policies.spec.ts
@@ -1,14 +1,50 @@
 import { RetryPolicies } from '../../src/resilience/retry.policies';
 import { ExponentialBackoffPolicy } from '../../src/resilience/policies/exponential-backoff.retry-policy';
+import { FixedDelayPolicy } from '../../src/resilience/policies/fixed-delay.retry-policy';
+import { LinearBackoffPolicy } from '../../src/resilience/policies/linear-backoff.retry-policy';
+import { FullJitterPolicy } from '../../src/resilience/policies/full-jitter.retry-policy';
+import { DecorrelatedJitterPolicy } from '../../src/resilience/policies/decorrelated-jitter.retry-policy';
 
 describe('RetryPolicies', () => {
-  describe('exponential', () => {
-    it('should return an ExponentialBackoffPolicy instance', () => {
-      expect(RetryPolicies.exponential(3)).toBeInstanceOf(ExponentialBackoffPolicy);
-    });
+  it('should return an ExponentialBackoffPolicy', () => {
+    expect(RetryPolicies.exponential(3)).toBeInstanceOf(ExponentialBackoffPolicy);
+  });
 
-    it('should use the default attempts value when called with no arguments', () => {
-      expect(RetryPolicies.exponential()).toBeInstanceOf(ExponentialBackoffPolicy);
-    });
+  it('should use default attempts for exponential', () => {
+    expect(RetryPolicies.exponential()).toBeInstanceOf(ExponentialBackoffPolicy);
+  });
+
+  it('should return a FixedDelayPolicy', () => {
+    expect(RetryPolicies.fixedDelay(3, 500)).toBeInstanceOf(FixedDelayPolicy);
+  });
+
+  it('should use defaults for fixedDelay', () => {
+    expect(RetryPolicies.fixedDelay()).toBeInstanceOf(FixedDelayPolicy);
+  });
+
+  it('should return a LinearBackoffPolicy', () => {
+    expect(RetryPolicies.linearBackoff(3, 200)).toBeInstanceOf(LinearBackoffPolicy);
+  });
+
+  it('should use defaults for linearBackoff', () => {
+    expect(RetryPolicies.linearBackoff()).toBeInstanceOf(LinearBackoffPolicy);
+  });
+
+  it('should return a FullJitterPolicy', () => {
+    expect(RetryPolicies.fullJitter(3, 100)).toBeInstanceOf(FullJitterPolicy);
+  });
+
+  it('should use defaults for fullJitter', () => {
+    expect(RetryPolicies.fullJitter()).toBeInstanceOf(FullJitterPolicy);
+  });
+
+  it('should return a DecorrelatedJitterPolicy', () => {
+    expect(RetryPolicies.decorrelatedJitter(3, 100, 30000)).toBeInstanceOf(
+      DecorrelatedJitterPolicy,
+    );
+  });
+
+  it('should use defaults for decorrelatedJitter', () => {
+    expect(RetryPolicies.decorrelatedJitter()).toBeInstanceOf(DecorrelatedJitterPolicy);
   });
 });


### PR DESCRIPTION
- Add RetryPredicate interface and retryIf() on RetryPolicy base class
- Move retryOn() to base class — all policies share the same retry decision
- Add FixedDelayPolicy, LinearBackoffPolicy, FullJitterPolicy, DecorrelatedJitterPolicy
- DecorrelatedJitterPolicy is stateless (attempt-based upper bound, no mutable state)
- Update README and README.tr.md with policy comparison table and retryIf examples
- Bump to 3.6.0