### PR TITLE
fix: replace explicit any with proper types across src and tests

### DIFF
--- a/src/exceptions/http-exception.factory.ts
+++ b/src/exceptions/http-exception.factory.ts
@@ -63,7 +63,7 @@ type HttpExceptionConstructor<T> = new (
  * Covers all standard 4xx client errors (400–451) and 5xx server errors (500–511).
  * Unmapped status codes fall through to the base {@link HttpException}.
  */
-const HttpStatusExceptionMap: Record<number, HttpExceptionConstructor<any>> = {
+const HttpStatusExceptionMap: Record<number, HttpExceptionConstructor<unknown>> = {
   400: BadRequestException,
   401: UnauthorizedException,
   402: PaymentRequiredException,
@@ -153,7 +153,12 @@ export class HttpExceptionFactory {
     const ExceptionClass = HttpStatusExceptionMap[status];
 
     if (ExceptionClass) {
-      return new ExceptionClass(response, message, code, cause);
+      return new ExceptionClass(
+        response as Response<unknown>,
+        message,
+        code,
+        cause,
+      ) as HttpException<T>;
     }
 
     return new HttpException(

--- a/src/models/request.ts
+++ b/src/models/request.ts
@@ -55,7 +55,7 @@ export class Request {
    * @param value - The value of the parameter.
    * @throws Error if the body is null (not initialized).
    */
-  public addParam(key: string, value: string | number | Record<string, any>) {
+  public addParam(key: string, value: string | number | HttpBody) {
     if (this.body == null) throw new Error('Body is not defined');
     this.body[key] = value;
   }

--- a/test/builders/request.builder.spec.ts
+++ b/test/builders/request.builder.spec.ts
@@ -1,6 +1,7 @@
 import { RequestBuilder } from '../../src/builders/request.builder';
 import { HttpMethod } from '../../src/common/enums/http-method.enum';
 import { ResponseValidator } from '../../src/contracts/response-validator.contract';
+import { HttpBody } from '../../src/common/types/http.types';
 
 describe('RequestBuilder', () => {
   let builder: RequestBuilder;
@@ -82,7 +83,7 @@ describe('RequestBuilder', () => {
 
     it('should handle undefined body in build', () => {
       // Force body to be undefined to hit the branch
-      builder.setBody(undefined as any);
+      builder.setBody(undefined as unknown as HttpBody);
       const request = builder.build();
       expect(request.body).toBeNull();
     });

--- a/test/contracts/retry-policy.contract.spec.ts
+++ b/test/contracts/retry-policy.contract.spec.ts
@@ -4,6 +4,7 @@ import { TimeoutException } from '../../src/exceptions/network.exceptions';
 import { NotFoundException } from '../../src/exceptions/http-status.exceptions';
 import { RetryPredicate } from '../../src/contracts/retry-predicate.contract';
 import { BaseAdapterException } from '../../src/exceptions/base-adapter.exception';
+import { Response } from '../../src/models/response';
 
 class TestPolicy extends RetryPolicy {
   maxAttempts = 3;
@@ -75,11 +76,9 @@ describe('RetryPolicy', () => {
     it('should delegate to shouldRetry on the predicate instance', () => {
       const predicate: RetryPredicate = { shouldRetry: () => true };
       policy.retryIf(predicate);
-      expect(
-        policy.retryOn(
-          new NotFoundException(HttpExceptionFactory.createFromResponse(404) as any, ''),
-        ),
-      ).toBe(true);
+      expect(policy.retryOn(new NotFoundException(Response.create(null, 404, null), ''))).toBe(
+        true,
+      );
     });
 
     it('should pass the error to shouldRetry', () => {

--- a/test/observability/http-adapter-observer.spec.ts
+++ b/test/observability/http-adapter-observer.spec.ts
@@ -5,14 +5,15 @@ import { Response } from '../../src/models/response';
 import { BaseAdapterException } from '../../src/exceptions/base-adapter.exception';
 import { RetryPolicies } from '../../src/resilience/retry.policies';
 import { TimeoutException } from '../../src/exceptions/network.exceptions';
+import { HttpClientContract } from '../../src/contracts/http-client.contract';
 
 const makeRequest = () =>
   new RequestBuilder('https://api.example.com').setEndpoint('/test').build();
 
 const mockClient = (
-  impl: () => Promise<{ data: any; status: number; headers: Record<string, string> }>,
-) => ({
-  request: jest.fn(impl),
+  impl: () => Promise<{ data: unknown; status: number; headers: Record<string, string> }>,
+): HttpClientContract => ({
+  request: jest.fn(impl) as HttpClientContract['request'],
 });
 
 describe('HttpAdapterObserver', () => {

--- a/test/resilience/circuit-breaker/circuit-breaker.spec.ts
+++ b/test/resilience/circuit-breaker/circuit-breaker.spec.ts
@@ -168,7 +168,7 @@ describe('CircuitBreaker', () => {
     it('should respect custom isFailure predicate', async () => {
       const cb = new CircuitBreaker({
         failureThreshold: 1,
-        isFailure: (err: any) => err.message !== 'ignore_me',
+        isFailure: (err: unknown) => err instanceof Error && err.message !== 'ignore_me',
       });
 
       await expect(


### PR DESCRIPTION
- Use HttpExceptionConstructor<unknown> in HttpStatusExceptionMap with explicit casts at the call site to preserve generic return type safety
- Replace Record<string, any> with string | number | HttpBody in addParam
- Use Response.create() instead of any cast in retry-policy contract test
- Cast jest mock to HttpClientContract['request'] in observer test
- Use unknown + instanceof guard in circuit-breaker isFailure predicate
- Use unknown as unknown as HttpBody for intentional undefined test case